### PR TITLE
Fix scenario runner accessibility

### DIFF
--- a/src/FluentScenario/ScenarioRunner.And.cs
+++ b/src/FluentScenario/ScenarioRunner.And.cs
@@ -2,7 +2,7 @@ using System.Runtime.CompilerServices;
 
 namespace DrifterApps.Seeds.FluentScenario;
 
-internal sealed partial class ScenarioRunner
+public sealed partial class ScenarioRunner
 {
     /// <inheritdoc/>
     public IScenarioRunner And(Action<IStepRunner> step)

--- a/src/FluentScenario/ScenarioRunner.Given.cs
+++ b/src/FluentScenario/ScenarioRunner.Given.cs
@@ -2,7 +2,7 @@ using System.Runtime.CompilerServices;
 
 namespace DrifterApps.Seeds.FluentScenario;
 
-internal sealed partial class ScenarioRunner
+public sealed partial class ScenarioRunner
 {
     /// <inheritdoc/>
     public IScenarioRunner Given(Action<IStepRunner> step)

--- a/src/FluentScenario/ScenarioRunner.RunnerContext.cs
+++ b/src/FluentScenario/ScenarioRunner.RunnerContext.cs
@@ -1,6 +1,6 @@
 namespace DrifterApps.Seeds.FluentScenario;
 
-internal sealed partial class ScenarioRunner
+public sealed partial class ScenarioRunner
 {
     /// <inheritdoc/>
     public void SetContextData(string contextKey, object data)

--- a/src/FluentScenario/ScenarioRunner.StepRunner.cs
+++ b/src/FluentScenario/ScenarioRunner.StepRunner.cs
@@ -2,7 +2,7 @@ using System.Runtime.CompilerServices;
 
 namespace DrifterApps.Seeds.FluentScenario;
 
-internal sealed partial class ScenarioRunner
+public sealed partial class ScenarioRunner
 {
     /// <inheritdoc/>
     public IStepRunner Execute(string description, Action stepExecution)

--- a/src/FluentScenario/ScenarioRunner.Then.cs
+++ b/src/FluentScenario/ScenarioRunner.Then.cs
@@ -2,7 +2,7 @@ using System.Runtime.CompilerServices;
 
 namespace DrifterApps.Seeds.FluentScenario;
 
-internal sealed partial class ScenarioRunner
+public sealed partial class ScenarioRunner
 {
     /// <inheritdoc/>
     public IScenarioRunner Then(Action<IStepRunner> step)

--- a/src/FluentScenario/ScenarioRunner.When.cs
+++ b/src/FluentScenario/ScenarioRunner.When.cs
@@ -2,7 +2,7 @@ using System.Runtime.CompilerServices;
 
 namespace DrifterApps.Seeds.FluentScenario;
 
-internal sealed partial class ScenarioRunner
+public sealed partial class ScenarioRunner
 {
     /// <inheritdoc/>
     public IScenarioRunner When(Action<IStepRunner> step)

--- a/src/FluentScenario/ScenarioRunner.cs
+++ b/src/FluentScenario/ScenarioRunner.cs
@@ -158,6 +158,6 @@ public sealed partial class ScenarioRunner : IScenarioRunner, IStepRunner
     /// <summary>
     /// Regular expression to match camel case patterns.
     /// </summary>
-    [GeneratedRegex("(?<!^)([A-Z])|_")]
+    [GeneratedRegex("(?<!^)([A-Z]|[0-9].*)|_")]
     private static partial Regex CamelToSentenceRegex();
 }

--- a/src/FluentScenario/ScenarioRunner.cs
+++ b/src/FluentScenario/ScenarioRunner.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
@@ -7,8 +6,7 @@ namespace DrifterApps.Seeds.FluentScenario;
 /// <summary>
 ///     Represents a runner for executing test scenarios.
 /// </summary>
-[SuppressMessage("Style", "IDE0042:Deconstruct variable declaration")]
-internal sealed partial class ScenarioRunner : IScenarioRunner, IStepRunner
+public sealed partial class ScenarioRunner : IScenarioRunner, IStepRunner
 {
     internal const string SuccessCheck = "\u001b[32m\u2713\u001b[0m";
     internal const string FailCheck = "\u001b[31m\u2717\u001b[0m";

--- a/tests/FluentScenario.Tests/Samples/ScenarioWithWellNamedMethodsTests.cs
+++ b/tests/FluentScenario.Tests/Samples/ScenarioWithWellNamedMethodsTests.cs
@@ -12,8 +12,8 @@ public class ScenarioWithWellNamedMethodsTests(ITestOutputHelper testOutputHelpe
     {
         await ScenarioRunner.Create(_scenarioOutput)
             .Given(IWantToGoPlayOutside)
-            .When(TheTemperatureIsBelow0C)
-            .Then(IStayInsideIfTheTemperatureDifferenceIsGreaterThan20C)
+            .When(TheTemperatureIsBelow0c)
+            .Then(IStayInsideIfTheTemperatureDifferenceIsGreaterThan20c)
             .PlayAsync();
     }
 
@@ -25,7 +25,7 @@ public class ScenarioWithWellNamedMethodsTests(ITestOutputHelper testOutputHelpe
         });
     }
 
-    private static void TheTemperatureIsBelow0C(IStepRunner runner)
+    private static void TheTemperatureIsBelow0c(IStepRunner runner)
     {
         runner.Execute(() =>
         {
@@ -33,7 +33,7 @@ public class ScenarioWithWellNamedMethodsTests(ITestOutputHelper testOutputHelpe
         });
     }
 
-    private static void IStayInsideIfTheTemperatureDifferenceIsGreaterThan20C(IStepRunner runner)
+    private static void IStayInsideIfTheTemperatureDifferenceIsGreaterThan20c(IStepRunner runner)
     {
         runner.Execute(() =>
         {


### PR DESCRIPTION
This pull request includes several changes to the `ScenarioRunner` class in the `FluentScenario` namespace, as well as updates to the test methods in `ScenarioWithWellNamedMethodsTests.cs`. The most important changes involve modifying the visibility of the `ScenarioRunner` class and adjusting method names for consistency.

Changes to `ScenarioRunner` class:

* Changed the visibility of the `ScenarioRunner` class from `internal` to `public` in multiple files to make it accessible outside the assembly. (`src/FluentScenario/ScenarioRunner.And.cs`, `src/FluentScenario/ScenarioRunner.Given.cs`, `src/FluentScenario/ScenarioRunner.RunnerContext.cs`, `src/FluentScenario/ScenarioRunner.StepRunner.cs`, `src/FluentScenario/ScenarioRunner.Then.cs`, `src/FluentScenario/ScenarioRunner.When.cs`, `src/FluentScenario/ScenarioRunner.cs`) [[1]](diffhunk://#diff-8a9f3e2b21a27d64070cac04632c4a47af92e1c469c7379beecc642a9e8bfc1eL5-R5) [[2]](diffhunk://#diff-016b9cb456e139979118d81bca3863fdfb383ed09795b79685463285f4451e93L5-R5) [[3]](diffhunk://#diff-9b0ca127ffd4e2f6c721eacb4faacbd279d517339159c98a0003e98f0d2ef0ffL3-R3) [[4]](diffhunk://#diff-47fb178cf738f7a85a10682aecde5eaf31378e595d8cdf8a3b3ac4548a8af743L5-R5) [[5]](diffhunk://#diff-4ea74af62535000a1bd3f2379ca16ecc97598dc55d3e92cee4fbf72f0c27243aL5-R5) [[6]](diffhunk://#diff-0030cb76359bc374e6c80d166835e22b6ede9c873ca7111afd281ee7dc86e044L5-R5) [[7]](diffhunk://#diff-eafd0a3cf6dfab69ecfb86d737d6671cb88070564cf0572bb1c807e969c26090L10-R9)
* Updated the regular expression in the `CamelToSentenceRegex` method to match camel case patterns that include digits. (`src/FluentScenario/ScenarioRunner.cs`)

Changes to test methods:

* Renamed methods to use lowercase 'c' for consistency in temperature-related method names. (`tests/FluentScenario.Tests/Samples/ScenarioWithWellNamedMethodsTests.cs`) [[1]](diffhunk://#diff-112a88f14e9ee69e8da2d9eeddbe2290f193a1e56b0a08864e6c89c07f20cee1L15-R16) [[2]](diffhunk://#diff-112a88f14e9ee69e8da2d9eeddbe2290f193a1e56b0a08864e6c89c07f20cee1L28-R36)