### PR TITLE
Make output messages to lower case

### DIFF
--- a/src/FluentScenario/ScenarioRunner.cs
+++ b/src/FluentScenario/ScenarioRunner.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
@@ -153,7 +154,8 @@ public sealed partial class ScenarioRunner : IScenarioRunner, IStepRunner
     /// <param name="description">The camel case string to convert.</param>
     /// <returns>The converted sentence.</returns>
     private static string CamelToSentence(string description) => CamelToSentenceRegex()
-        .Replace(description, m => m.Groups[1].Success ? " " + m.Groups[1].Value : "").Trim();
+        .Replace(description, m => m.Groups[1].Success ? " " + m.Groups[1].Value : "").Trim()
+        .ToLower(CultureInfo.CurrentCulture);
 
     /// <summary>
     /// Regular expression to match camel case patterns.

--- a/tests/FluentScenario.Tests/ScenarioRunnerTests.cs
+++ b/tests/FluentScenario.Tests/ScenarioRunnerTests.cs
@@ -51,7 +51,7 @@ public class ScenarioRunnerTests
 
         // assert
         _scenarioOutput.Received().WriteLine(
-            Arg.Is<string>(x => x.Contains("Given Scenario When No Description Then Scenario Is Member Name")));
+            Arg.Is<string>(x => x.Contains("given scenario when no description then scenario is member name")));
     }
 
     [Fact]
@@ -357,13 +357,13 @@ public class ScenarioRunnerTests
 
     [Theory]
     [ClassData(typeof(AndRunnerData))]
-    public async Task GivenMethod_WhenFirst_ThenShouldBeGiven(string methodName, MockScenarioOutput output,
+    public async Task OutputTests(string methodName, MockScenarioOutput output,
         object step)
     {
         // arrange
         var description = "description";
         output.Reset();
-        var sut = ScenarioRunner.Create("Testing StepRunner Execute", output);
+        var sut = ScenarioRunner.Create(output);
 
         // act
         sut.InvokeStep(methodName, description, step);
@@ -375,15 +375,15 @@ public class ScenarioRunnerTests
         // assert
         var upperMethodName = methodName == "And" ? "GIVEN" : methodName.ToUpper(CultureInfo.InvariantCulture);
         _ = output.Messages.Should().HaveCount(9).And.ContainInOrder(
-            $"{ScenarioRunner.SuccessCheck} SCENARIO for Testing StepRunner Execute",
+            $"{ScenarioRunner.SuccessCheck} SCENARIO for output tests",
             OutputFromExecute,
             $"{ScenarioRunner.SuccessCheck} {upperMethodName} {description}",
             OutputFromExecute,
             $"{ScenarioRunner.SuccessCheck} and {description}",
             OutputFromExecute,
-            $"{ScenarioRunner.SuccessCheck} and Caller Member Name Attribute",
+            $"{ScenarioRunner.SuccessCheck} and caller member name attribute",
             OutputFromExecute,
-            $"{ScenarioRunner.SuccessCheck} and Caller Member Name Attribute"
+            $"{ScenarioRunner.SuccessCheck} and caller member name attribute"
             );
     }
 


### PR DESCRIPTION
For better readability, make output messages to lower case when generated from caller method name